### PR TITLE
Update Influx version to 1.8.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.14
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
This PR Updates InfluxDB to 1.8.10 from 1.8.3.

**Testing**
Influx image was built and tested in the Appwrite stack.