### PR TITLE
Fix(deploy): remove exit command when influx is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ script:
   - >
     if : >/dev/tcp/localhost/8086; then
       echo 'Connection available.'
-      travis_terminate 0
     else
       echo 'Connection unavailable.'
       travis_terminate 1


### PR DESCRIPTION
This PR removes the `travis_terminate` call when InfluxDB is available, so deployment can continue.
https://github.com/appwrite/docker-influxdb/blob/d9ac5dc23ab2651bfb3b18d8d06b0d525659732b/.travis.yml#L34-L40

The `travis_terminate` command completely kills the build, even when `exitcode=0`.
```bash
_travis_terminate_unix() {
  ...
  pkill -9 -P "${$}" &>/dev/null || true
  exit "${1}"
}
```
ref: https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_terminate.bash