### PR TITLE
Add support for dependabot, Bump Alpine to 3.15.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/dependabot.yml
+++ b/.github/ISSUE_TEMPLATE/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain Docker images updated
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM alpine:3.15
+FROM alpine:3.15.1
 
 LABEL maintainer="team@appwrite.io"
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 
-RUN apk add --no-cache \
+RUN apk -U upgrade && \
+    apk add --no-cache \
         tzdata \
         bash \
         ca-certificates && \


### PR DESCRIPTION
* Bump Alpine to v3.15.1 which introduces fixes for several CVE's including BusyBox, OpenSSL, etc
* Add support for dependabot, to auto create PR's when the base image gets updated.
* Add `apk -U upgrade` to catch any base alpine package that needs to be updated.